### PR TITLE
Feature/composableconfiguration

### DIFF
--- a/Heliar.ComponentModel.Composition.Web/CompositionProvider.cs
+++ b/Heliar.ComponentModel.Composition.Web/CompositionProvider.cs
@@ -36,9 +36,9 @@ namespace Heliar.ComponentModel.Composition.Web
 				initialCatalog = new WebApplicationCatalog();
 
 			var globals = initialCatalog.Filter(cpd => cpd.ContainsPartMetadata(ApplicationShared, true));
-		    var compositionContainer = new CompositionContainer(globals, CompositionOptions.DisableSilentRejection | CompositionOptions.IsThreadSafe);
-		    ConfigureContainer(compositionContainer);
-		    applicationScopeContainer = compositionContainer;
+			var compositionContainer = new CompositionContainer(globals, CompositionOptions.DisableSilentRejection | CompositionOptions.IsThreadSafe);
+			ConfigureContainer(compositionContainer);
+			applicationScopeContainer = compositionContainer;
 
 			requestScopeCatalog = globals.Complement;
 
@@ -51,14 +51,15 @@ namespace Heliar.ComponentModel.Composition.Web
 			}
 		}
 
-	    static void ConfigureContainer(CompositionContainer compositionContainer) {
-	        var compositionBatch = new CompositionBatch();
-	        compositionBatch.AddExportedValue(compositionContainer);
-            compositionBatch.AddExportedValue(compositionContainer.Catalog);
-	        compositionContainer.Compose(compositionBatch);
-	    }
+		static void ConfigureContainer(CompositionContainer compositionContainer)
+		{
+			var compositionBatch = new CompositionBatch();
+			compositionBatch.AddExportedValue(compositionContainer);
+			compositionBatch.AddExportedValue(compositionContainer.Catalog);
+			compositionContainer.Compose(compositionBatch);
+		}
 
-	    /// <summary>
+		/// <summary>
 		/// Gets the composition container for the current scope.
 		/// </summary>
 		/// <value>The current.</value>
@@ -70,15 +71,16 @@ namespace Heliar.ComponentModel.Composition.Web
 			}
 		}
 
-	    static CompositionContainer BeginScope() {
-	        var compositionContainer = new CompositionContainer(requestScopeCatalog,
-	            CompositionOptions.DisableSilentRejection | CompositionOptions.IsThreadSafe, 
-	            applicationScopeContainer);
-            ConfigureContainer(compositionContainer);
-	        return compositionContainer;
-	    }
+		static CompositionContainer BeginScope()
+		{
+			var compositionContainer = new CompositionContainer(requestScopeCatalog,
+				CompositionOptions.DisableSilentRejection | CompositionOptions.IsThreadSafe, 
+				applicationScopeContainer);
+			ConfigureContainer(compositionContainer);
+			return compositionContainer;
+		}
 
-	    /// <summary>
+		/// <summary>
 		/// Gets the initialized composition container for the current scope.
 		/// </summary>
 		/// <value>The current initialised scope.</value>


### PR DESCRIPTION
Hi,

I propose the following changes to export the container and it's parts catalog for use e.g in other Dependency Resolvers (I am personally using it for ShortBus, and am looking to perhaps use it also in a SignalR dependency resolver).

Ideally though, I believe we should be able to setup composable parts in consuming libraries/apps instead.
Perhaps it could be a good idea to extend the WebApplicationCatalog or create some other mechanism for this.

PS big thanks for this elegant scope solution for MEF for MVC, been looking for a while and was about to roll my own until I came across yours :) Kinda couldn't believe only WebApi has built-in support for scopes...
